### PR TITLE
Improve tools API pagination and homepage loading experience

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -43,6 +43,13 @@ class Tool(ToolBase):
             }
         }
 
+
+class PaginatedTools(BaseModel):
+    items: List[Tool]
+    total: int
+    page: int
+    page_size: int
+
 class CategoryModel(BaseModel):
     name: str
     description: Optional[str] = None

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -393,6 +393,35 @@
   font-size: 18px;
 }
 
+.load-more-container {
+  text-align: center;
+  margin: 40px auto 80px;
+}
+
+.load-more-button {
+  background: linear-gradient(135deg, #e91e63 0%, #b91c8f 100%);
+  color: white;
+  padding: 14px 36px;
+  border: none;
+  border-radius: 999px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 10px 25px rgba(185, 28, 143, 0.25);
+  transition: transform 0.2s, box-shadow 0.2s, opacity 0.2s;
+}
+
+.load-more-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 35px rgba(185, 28, 143, 0.35);
+}
+
+.load-more-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  box-shadow: none;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .hero-title {

--- a/frontend/src/pages/admin/ToolsManagement.js
+++ b/frontend/src/pages/admin/ToolsManagement.js
@@ -14,7 +14,6 @@ const createEmptyFormData = () => ({
     is_active: true,
     is_featured: false
   });
-});
 
 const ToolsManagement = () => {
   const [tools, setTools] = useState([]);
@@ -42,11 +41,39 @@ const ToolsManagement = () => {
 
   const fetchTools = async () => {
     try {
-      const response = await axios.get(`${API}/tools`);
-      setTools(response.data);
-      setLoading(false);
+      const pageSize = 100;
+      let currentPage = 1;
+      let hasMore = true;
+      const aggregatedTools = [];
+
+      while (hasMore) {
+        const response = await axios.get(`${API}/tools`, {
+          params: {
+            page: currentPage,
+            page_size: pageSize
+          }
+        });
+
+        const data = response.data;
+        const items = Array.isArray(data) ? data : data.items || [];
+
+        aggregatedTools.push(...items);
+
+        if (items.length === 0) {
+          hasMore = false;
+        } else if (!Array.isArray(data) && typeof data.total === 'number') {
+          hasMore = currentPage * pageSize < data.total;
+        } else {
+          hasMore = items.length === pageSize;
+        }
+
+        currentPage += 1;
+      }
+
+      setTools(aggregatedTools);
     } catch (error) {
       console.error('Error fetching tools:', error);
+    } finally {
       setLoading(false);
     }
   };


### PR DESCRIPTION
## Summary
- replace the `/api/tools` list response with a paginated payload that supports page and page_size parameters and caps requests
- update the homepage to fetch smaller batches, support filter-driven pagination, and expose a "load more" control with matching styles
- adjust admin tooling and automated backend checks to consume the paginated response format

## Testing
- python -m compileall backend
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68ff14a59b10832686818aa527c46c0e